### PR TITLE
* external/ocamlzip/zip.ml: remove duplicate exception.

### DIFF
--- a/external/ocamlzip/zip.ml
+++ b/external/ocamlzip/zip.ml
@@ -73,8 +73,6 @@ type out_file =
     mutable of_entries: entry list;
     of_comment: string }
 
-exception Error of string * string * string
-
 (* Return the position of the last occurrence of s1 in s2, or -1 if not
    found. *)
 


### PR DESCRIPTION
It is causing compilation error with ocaml 4.02.3 apparently.
Should fix issue #133 and issue #145
